### PR TITLE
New Dev Feature: Use Better Typings

### DIFF
--- a/components/Chat.tsx
+++ b/components/Chat.tsx
@@ -1,17 +1,17 @@
 import { useUser } from "@clerk/clerk-react";
 import Image from "next/image";
 import { useRouter } from "next/router";
-import React from "react";
 import { useCollection } from "react-firebase-hooks/firestore";
 import { db } from "../firebase";
 import getRecipientEmail from "../utils/getRecipientEmail";
+import { NextComponentType, NextPageContext } from "next";
 
 type ChatProps = {
   id: string;
   users: [string];
 };
 
-const Chat: React.FC<ChatProps> = ({ id, users }) => {
+const Chat: NextComponentType<NextPageContext, {}, ChatProps> = ({ id, users }) => {
   const router = useRouter();
   const user = useUser();
   const [recipientSnapshot] = useCollection(

--- a/components/ChatScreen.tsx
+++ b/components/ChatScreen.tsx
@@ -21,6 +21,7 @@ import { MessageType } from "../types/MessageType";
 import getRecipientEmail from "../utils/getRecipientEmail";
 import ChatScreenHeader from "./ChatScreenHeader";
 import Message from "./Message";
+import { NextComponentType, NextPageContext } from "next";
 
 declare global {
   // eslint-disable-next-line no-unused-vars
@@ -43,7 +44,7 @@ interface Props {
   messages: string;
 }
 
-const ChatScreen: React.FC<Props> = ({ chat, messages }) => {
+const ChatScreen: NextComponentType<NextPageContext, {}, Props> = ({ chat, messages }) => {
   const user = useUser();
   const router = useRouter();
   const endOfMessagesRef = useRef<HTMLInputElement>(null);

--- a/components/ChatScreenHeader.tsx
+++ b/components/ChatScreenHeader.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import Image from "next/image";
 import TimeAgo from "timeago-react";
 import React from "react";
+import { NextComponentType, NextPageContext } from "next";
 
 interface Props {
   recipient: {
@@ -17,7 +18,7 @@ interface Props {
   recipientSnapshot: any;
 }
 
-const ChatScreenHeader: React.FC<Props> = ({
+const ChatScreenHeader: NextComponentType<NextPageContext, {}, Props> = ({
   recipient,
   recipientEmail,
   recipientSnapshot,

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -1,7 +1,8 @@
 import Fade from "react-reveal/Fade";
 import { useRouter } from "next/router";
+import { NextComponentType } from "next";
 
-function Footer() {
+const Footer: NextComponentType = () => {
   const router = useRouter();
   if (router.pathname.match("/")) {
     return null;

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,8 +1,9 @@
 import Image from "next/image";
 import Link from "next/link";
 import Fade from "react-reveal/Fade";
+import { NextComponentType } from "next";
 
-function Header() {
+const Header: NextComponentType = () => {
   return (
     <Fade top>
       <header className="px-5 m-4 text-center rounded-lg">

--- a/components/Message.tsx
+++ b/components/Message.tsx
@@ -11,6 +11,7 @@ import React, { Fragment, useRef, useState } from "react";
 import Linkify from "react-linkify";
 import { db } from "../firebase";
 import { MessageType } from "../types/MessageType";
+import { NextComponentType, NextPageContext } from "next";
 
 type MessageProps = {
   message: MessageType;
@@ -18,7 +19,12 @@ type MessageProps = {
   id: string;
 };
 
-const Message: React.FC<MessageProps> = ({ message, creatorEmail, id }) => {
+ 
+const Message: NextComponentType<NextPageContext, {}, MessageProps> = ({
+  message,
+  creatorEmail,
+  id,
+}) => {
   const user = useUser();
   const userLoggedIn = user?.primaryEmailAddress?.emailAddress;
   const TypeOfMessage = creatorEmail === userLoggedIn ? "Sender" : "Receiver";

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -14,6 +14,7 @@ import { useKeyPress } from "../hooks/useKeyPress";
 import { UsersType } from "../types/UserType";
 import Chat from "./Chat";
 import ThemeToggler from "./ThemeToggler";
+import { NextComponentType } from "next";
 
 interface ChatType {
   id: string;
@@ -26,7 +27,7 @@ interface UserFilterType {
   };
 }
 
-const Sidebar = () => {
+const Sidebar: NextComponentType = () => {
   const user = useUser();
   const [users, setUsers] = useState<any>([]);
   const [inputValue, setInputValue] = useState("");

--- a/components/ThemeToggler.tsx
+++ b/components/ThemeToggler.tsx
@@ -1,6 +1,7 @@
 import useDarkMode from "../hooks/useDarkMode";
+import { NextComponentType } from "next";
 
-const ThemeToggler = () => {
+const ThemeToggler: NextComponentType = () => {
   const [colorTheme, setTheme] = useDarkMode();
 
   return (

--- a/pages/app.tsx
+++ b/pages/app.tsx
@@ -8,8 +8,9 @@ import "firebase/compat/firestore";
 import Fade from "react-reveal/Fade";
 import Image from "next/image";
 import { useUser } from "@clerk/clerk-react";
+import type { NextPage } from "next";
 
-export default function Home() {
+const Home: NextPage = () => {
   const user = useUser();
 
   useEffect(() => {
@@ -62,3 +63,5 @@ export default function Home() {
     </div>
   );
 }
+
+export default Home

--- a/pages/chat/[id].tsx
+++ b/pages/chat/[id].tsx
@@ -1,10 +1,11 @@
 import { useUser } from "@clerk/clerk-react";
 import { useRouter } from "next/router";
-import React, { useEffect } from "react";
+import { useEffect } from "react";
 import ChatScreen from "../../components/ChatScreen";
 import Sidebar from "../../components/Sidebar";
 import { db } from "../../firebase";
 import { UserType } from "../../types/UserType";
+import type { GetServerSideProps, NextPage } from "next";
 
 interface ChatProps {
   chat: {
@@ -15,7 +16,7 @@ interface ChatProps {
   users: [UserType];
 }
 
-const Chat: React.FC<ChatProps> = ({ chat, messages, users }) => {
+const Chat: NextPage<ChatProps> = ({ chat, messages, users }) => {
   const router = useRouter();
   const user = useUser();
   const userEmail = user?.primaryEmailAddress?.emailAddress as string;
@@ -38,7 +39,7 @@ const Chat: React.FC<ChatProps> = ({ chat, messages, users }) => {
 
 export default Chat;
 
-export async function getServerSideProps(context: any) {
+export const getServerSideProps: GetServerSideProps = async (context) => {
   const ref = db.collection("chats").doc(context.query.id);
   const allusers = await db.collection("users").get();
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,8 +8,9 @@ import "firebase/compat/firestore";
 import Fade from "react-reveal/Fade";
 import Image from "next/image";
 import { useUser } from "@clerk/clerk-react";
+import type { NextPage } from "next";
 
-export default function Home() {
+const Home: NextPage = () => {
   const user = useUser();
 
   useEffect(() => {
@@ -62,3 +63,5 @@ export default function Home() {
     </div>
   );
 }
+
+export default Home

--- a/pages/sign-in/[[...index]].tsx
+++ b/pages/sign-in/[[...index]].tsx
@@ -2,8 +2,9 @@ import { NextSeo } from "next-seo";
 import { SignIn } from "@clerk/clerk-react";
 import Header from "../../components/Header";
 import Footer from "../../components/Footer";
+import type { NextPage } from "next";
 
-export default function SignInPage() {
+const SignInPage: NextPage = () => {
   return (
     <div className="bg-indigo-700">
       <NextSeo title="Sign in to ChatCube" />
@@ -14,3 +15,5 @@ export default function SignInPage() {
     </div>
   );
 }
+
+export default SignInPage

--- a/pages/sign-up/[[...index]].tsx
+++ b/pages/sign-up/[[...index]].tsx
@@ -2,8 +2,9 @@ import { NextSeo } from "next-seo";
 import { SignUp } from "@clerk/clerk-react";
 import Footer from "../../components/Footer";
 import Header from "../../components/Header";
+import type { NextPage } from "next";
 
-export default function SignUpPage() {
+const SignUpPage: NextPage = () => {
   return (
     <div className="bg-indigo-700">
       <NextSeo title="Sign up to ChatCube" />
@@ -13,3 +14,5 @@ export default function SignUpPage() {
     </div>
   );
 }
+
+export default SignUpPage

--- a/pages/user/[[...index]].tsx
+++ b/pages/user/[[...index]].tsx
@@ -1,8 +1,9 @@
 import { NextSeo } from "next-seo";
 import { UserProfile } from "@clerk/clerk-react";
 import Header from "../../components/Header";
+import type { NextPage } from "next";
 
-export default function UserProfilePage() {
+const UserProfilePage: NextPage = () => {
   return (
     <div className="bg-indigo-700">
       <NextSeo title="Your profile" />
@@ -11,3 +12,5 @@ export default function UserProfilePage() {
     </div>
   );
 }
+
+export default UserProfilePage


### PR DESCRIPTION
Hello. I basically changed the types on the components and pages to use the built in Next JS types (apparently using something like React.FC is discouraged.)

For example, in `components/Chat.tsx`, it used to be:

```tsx
const Chat: React.FC<ChatProps> = ({ id, users }) => {
  // ...
}
```

Now it is 
```tsx
const Chat: NextComponentType<NextPageContext, {}, ChatProps> = ({ id, users }) => {
  // ...
}
```